### PR TITLE
CIVICRM-914: Replaced get_headers functions call with cURL request.

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -908,7 +908,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
 
     // Does arrow.png exist where we expect it?
     $arrowUrl = CRM_Core_Config::singleton()->userFrameworkResourceURL . 'packages/jquery/css/images/arrow.png';
-    $headers = get_headers($arrowUrl);
+    $headers = CRM_Utils_Curl::getHeaders($arrowUrl);
     $fileExists = stripos($headers[0], "200 OK") ? 1 : 0;
     if (!$fileExists) {
       $messages[] = new CRM_Utils_Check_Message(

--- a/CRM/Utils/Check/Component/Security.php
+++ b/CRM/Utils/Check/Component/Security.php
@@ -86,7 +86,7 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
         if (count($log_path) > 1) {
           $url[] = $log_path[1];
           $log_url = implode($filePathMarker, $url);
-          $headers = @get_headers($log_url);
+          $headers = @CRM_Utils_Curl::getHeaders($log_url);
           if (stripos($headers[0], '200')) {
             $docs_url = $this->createDocUrl('checkLogFileIsNotAccessible');
             $msg = 'The <a href="%1">CiviCRM debug log</a> should not be downloadable.'
@@ -365,7 +365,7 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
       return FALSE;
     }
 
-    $headers = @get_headers("$url/$file");
+    $headers = @CRM_Utils_Curl::getHeaders("$url/$file");
     if (stripos($headers[0], '200')) {
       $content = @file_get_contents("$url/$file");
       if (preg_match('/delete me/', $content)) {

--- a/CRM/Utils/Curl.php
+++ b/CRM/Utils/Curl.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 5                                                  |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2018
+ */
+class CRM_Utils_Curl {
+
+  /**
+   * Return headers from given URL using Curl
+   *
+   * @param $url
+   * @return array
+   */
+  public static function getHeaders($url, $maxtimeout = 250) {
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    curl_setopt($ch, CURLOPT_HEADER, 1);
+    curl_setopt($ch, CURLOPT_NOBODY, 1);
+
+    curl_setopt($ch, CURLOPT_TIMEOUT_MS, $maxtimeout); // in milliseconds
+
+    $curlresponse = curl_exec($ch);
+    curl_close($ch);
+
+    $headers = array();
+    $headersData = explode("\n", $curlresponse);
+
+    foreach ($headersData as $headerData) {
+      if (trim($headerData)) {
+        $headers[] = $headerData;
+      }
+    }
+    return $headers;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Instances of **get_headers** functions call has been replaced with cURL requests. Default timeout for the request is **250ms** and can be changed as needed for different requests.

Comments
----------------------------------------
_Agileware Ref: CIVICRM-914_
